### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/proj_1/iitable/iitable.py
+++ b/proj_1/iitable/iitable.py
@@ -47,7 +47,7 @@ class WordChain(object):
     def union(chain_one, chain_two):
         node_one = chain_one.head
         node_two = chain_two.head
-        new_word = '%s OR %s' % (chain_one.word, chain_two.word)
+        new_word = '{0!s} OR {1!s}'.format(chain_one.word, chain_two.word)
         new_chain = WordChain(new_word)
 
         while (node_one is not None) and (node_two is not None):
@@ -73,7 +73,7 @@ class WordChain(object):
     def intersection(chain_one, chain_two):
         node_one = chain_one.head
         node_two = chain_two.head
-        new_word = '%s AND %s' % (chain_one.word, chain_two.word)
+        new_word = '{0!s} AND {1!s}'.format(chain_one.word, chain_two.word)
         new_chain = WordChain(new_word)
 
         while (node_one is not None) and (node_two is not None):
@@ -93,7 +93,7 @@ class WordChain(object):
     def diff(chain_one, chain_two):
         node_one = chain_one.head
         node_two = chain_two.head
-        new_word = '%s AND NOT %s' % (chain_one.word, chain_two.word)
+        new_word = '{0!s} AND NOT {1!s}'.format(chain_one.word, chain_two.word)
         new_chain = WordChain(new_word)
 
         while (node_one is not None) and (node_two is not None):
@@ -115,7 +115,7 @@ class WordChain(object):
         return new_chain
 
     def __str__(self):
-        chain_str = '(%s, freq:%d) *' % (self.word, self.freq)
+        chain_str = '({0!s}, freq:{1:d}) *'.format(self.word, self.freq)
         if self.head is not None:
             node_to_print = self.head
             while node_to_print is not None:
@@ -233,6 +233,6 @@ def doc_loc(doc_id):
     Returns:
        A string of the absolute path to the doc file.
     '''
-    file_name = '../data/pp_%d.txt' % doc_id
+    file_name = '../data/pp_{0:d}.txt'.format(doc_id)
     path = os.path.join(os.path.dirname(__file__), file_name)
     return path

--- a/proj_1/test/test_iitable.py
+++ b/proj_1/test/test_iitable.py
@@ -112,7 +112,7 @@ class TestIITable(unittest.TestCase):
     def test_build_sitable(self):
         doc_path_list = []
         for i in range(3):
-            file_name = 'test_data%d.txt' % (i + 1)
+            file_name = 'test_data{0:d}.txt'.format((i + 1))
             doc_path_list.append(os.path.join(DATA_FILE_DIR, file_name))
         doc_list = (process_doc(doc_path_list[i], i + 1) for i in range(3))
         item_count = 0
@@ -130,7 +130,7 @@ class TestIITable(unittest.TestCase):
     def test_build_iitable(self):
         doc_path_list = []
         for i in range(3):
-            file_name = 'test_data%d.txt' % (i + 1)
+            file_name = 'test_data{0:d}.txt'.format((i + 1))
             doc_path_list.append(os.path.join(DATA_FILE_DIR, file_name))
         doc_list = (process_doc(doc_path_list[i], i + 1) for i in range(3))
         iitable = build_iitable(build_sitable(doc_list))
@@ -144,7 +144,7 @@ class TestIITable(unittest.TestCase):
     def test_chain_union(self):
         doc_path_list = []
         for i in range(3):
-            file_name = 'test_data%d.txt' % (i + 1)
+            file_name = 'test_data{0:d}.txt'.format((i + 1))
             doc_path_list.append(os.path.join(DATA_FILE_DIR, file_name))
         doc_list = (process_doc(doc_path_list[i], i + 1) for i in range(3))
         iitable = build_iitable(build_sitable(doc_list))
@@ -172,7 +172,7 @@ class TestIITable(unittest.TestCase):
     def test_chain_intersection(self):
         doc_path_list = []
         for i in range(3):
-            file_name = 'test_data%d.txt' % (i + 1)
+            file_name = 'test_data{0:d}.txt'.format((i + 1))
             doc_path_list.append(os.path.join(DATA_FILE_DIR, file_name))
         doc_list = (process_doc(doc_path_list[i], i + 1) for i in range(3))
         iitable = build_iitable(build_sitable(doc_list))
@@ -192,7 +192,7 @@ class TestIITable(unittest.TestCase):
     def test_chain_diff(self):
         doc_path_list = []
         for i in range(3):
-            file_name = 'test_data%d.txt' % (i + 1)
+            file_name = 'test_data{0:d}.txt'.format((i + 1))
             doc_path_list.append(os.path.join(DATA_FILE_DIR, file_name))
         doc_list = (process_doc(doc_path_list[i], i + 1) for i in range(3))
         iitable = build_iitable(build_sitable(doc_list))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:lonelyandrew:IRC?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:lonelyandrew:IRC?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)