### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/proj_1/iitable/iitable.py
+++ b/proj_1/iitable/iitable.py
@@ -48,7 +48,7 @@ class WordChain(object):
     def union(chain_one, chain_two):
         node_one = chain_one.head
         node_two = chain_two.head
-        new_word = '%s AND %s' % (chain_one.word, chain_two.word)
+        new_word = '{0!s} AND {1!s}'.format(chain_one.word, chain_two.word)
         new_chain = WordChain(new_word)
 
         while (node_one is not None) and (node_two is not None):
@@ -74,7 +74,7 @@ class WordChain(object):
     def intersection(chain_one, chain_two):
         node_one = chain_one.head
         node_two = chain_two.head
-        new_word = '%s OR %s' % (chain_one.word, chain_two.word)
+        new_word = '{0!s} OR {1!s}'.format(chain_one.word, chain_two.word)
         new_chain = WordChain(new_word)
 
         while (node_one is not None) and (node_two is not None):
@@ -94,7 +94,7 @@ class WordChain(object):
     def diff(chain_one, chain_two):
         node_one = chain_one.head
         node_two = chain_two.head
-        new_word = '%s AND NOT %s' % (chain_one.word, chain_two.word)
+        new_word = '{0!s} AND NOT {1!s}'.format(chain_one.word, chain_two.word)
         new_chain = WordChain(new_word)
 
         while (node_one is not None) and (node_two is not None):
@@ -116,7 +116,7 @@ class WordChain(object):
         return new_chain
 
     def __str__(self):
-        chain_str = '(%s, freq:%d) O' % (self.word, self.freq)
+        chain_str = '({0!s}, freq:{1:d}) O'.format(self.word, self.freq)
         if self.head is not None:
             node_to_print = self.head
             while node_to_print is not None:
@@ -230,6 +230,6 @@ def doc_loc(doc_id):
     Returns:
        A string of the absolute path to the doc file.
     '''
-    file_name = '../data/pp_%d.txt' % doc_id
+    file_name = '../data/pp_{0:d}.txt'.format(doc_id)
     path = os.path.join(os.path.dirname(__file__), file_name)
     return path


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:lonelyandrew:IRC?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:lonelyandrew:IRC?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)